### PR TITLE
Defer install event publication until plugin base url is configured

### DIFF
--- a/src/main/java/minhhai2209/jirapluginconverter/plugin/lifecycle/PluginLifeCycleEventHandler.java
+++ b/src/main/java/minhhai2209/jirapluginconverter/plugin/lifecycle/PluginLifeCycleEventHandler.java
@@ -96,7 +96,10 @@ public class PluginLifeCycleEventHandler {
 
   private void notify(StringBuilder error, EventType eventType, String uri, String sharedSecret, String jwt) throws Exception {
     try {
-      if (uri != null) {
+      String configuredPluginBaseUrl = PluginSetting.getPluginBaseUrl();
+
+      if (uri != null && configuredPluginBaseUrl != null && !configuredPluginBaseUrl.isEmpty()) {
+        System.out.println(PluginSetting.getDescriptor().getKey() + " PLUGIN NOTIFY EVENT: " + "publishing install payload to: " + configuredPluginBaseUrl + uri);
         PluginLifeCycleEvent event = new PluginLifeCycleEvent();
         event.setBaseUrl(JiraUtils.getFullBaseUrl());
         event.setClientKey(KeyUtils.getClientKey());
@@ -110,6 +113,8 @@ public class PluginLifeCycleEventHandler {
         event.setServiceEntitlementNumber(SenUtils.getSen());
         event.setSharedSecret(sharedSecret);
         notify(uri, event, jwt, error);
+      } else {
+        System.out.println(PluginSetting.getDescriptor().getKey() + " PLUGIN NOTIFY EVENT: suppressing notification. no plugin base url configured.");
       }
     } catch (Exception e) {
       System.out.println(PluginSetting.getDescriptor().getKey() + " PLUGIN NOTIFY EVENT '" +

--- a/src/main/resources/templates/configure-plugin.vm
+++ b/src/main/resources/templates/configure-plugin.vm
@@ -67,7 +67,7 @@
           </div>
           <div class="field-group">
             <label for="url">$i18n.getText("plugin.configuration.url.label")</label>
-            <input type="text" value="$url" id="url" name="url" class="text">
+            <input type="url" required pattern="https?://.+"  value="$url" id="url" name="url" class="text">
             <div class="aui-description description">$i18n.getText("plugin.configuration.url.description")</div>
           </div>
         </div>


### PR DESCRIPTION
This is helpful for when you do not want the plugin to attempt to communicate with an internal or external url until explicitly instructed to do so. In this case, the `baseUrl` key for `imported_atlas_connect_descriptor.json` should be set to an empty string after running to converter and generating your target website (manually modify the descriptor by hand after it is generated).